### PR TITLE
Retrieve user profile image reference API

### DIFF
--- a/src/main/java/com/prx/backoffice/v1/profileimage/api/controller/ProfileImageApi.java
+++ b/src/main/java/com/prx/backoffice/v1/profileimage/api/controller/ProfileImageApi.java
@@ -14,6 +14,7 @@
 package com.prx.backoffice.v1.profileimage.api.controller;
 
 import com.prx.backoffice.v1.profileimage.service.ProfileImageService;
+import com.prx.backoffice.v1.profileimage.to.GetProfileImageReferenceResponse;
 import com.prx.backoffice.v1.profileimage.to.PostProfileImageResponse;
 import com.prx.commons.util.HttpStatusUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -79,5 +80,27 @@ public interface ProfileImageApi {
     ) throws Exception {
         return ResponseEntity.status(HttpStatusUtil.NOT_IMPLEMENTED).body(new byte[0]);
     }
-}
 
+    /**
+     * Retrieves the profile image reference for a user.
+     *
+     * @param token the session token of the user
+     * @param applicationId the ID of the application
+     * @return ResponseEntity with the profile image reference
+     * @throws Exception if retrieval fails
+     */
+    @Operation(summary = "Get profile image reference", description = "Retrieves the profile image reference for a user.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = HttpStatusUtil.OK_STR, description = "Profile image reference retrieved successfully"),
+        @ApiResponse(responseCode = HttpStatusUtil.NOT_FOUND_STR, description = "Profile image reference not found"),
+        @ApiResponse(responseCode = HttpStatusUtil.UNAUTHORIZED_STR, description = "Unauthorized access"),
+        @ApiResponse(responseCode = HttpStatusUtil.INTERNAL_SERVER_ERROR_STR, description = "Server error")
+    })
+    @GetMapping(value = "/application/{applicationId}/reference", produces = {MediaType.APPLICATION_JSON_VALUE})
+    default ResponseEntity<GetProfileImageReferenceResponse> getProfileImageReference(
+            @Parameter(description = "Token session", required = true) @RequestHeader(SESSION_TOKEN_KEY) String token,
+            @Parameter(description = "Application Id", required = true) @PathVariable("applicationId") UUID applicationId
+    ) throws Exception {
+        return ResponseEntity.status(HttpStatusUtil.NOT_IMPLEMENTED).body(null);
+    }
+}

--- a/src/main/java/com/prx/backoffice/v1/profileimage/api/controller/ProfileImageController.java
+++ b/src/main/java/com/prx/backoffice/v1/profileimage/api/controller/ProfileImageController.java
@@ -14,6 +14,7 @@
 package com.prx.backoffice.v1.profileimage.api.controller;
 
 import com.prx.backoffice.v1.profileimage.service.ProfileImageService;
+import com.prx.backoffice.v1.profileimage.to.GetProfileImageReferenceResponse;
 import com.prx.backoffice.v1.profileimage.to.PostProfileImageResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -53,5 +54,12 @@ public class ProfileImageController implements ProfileImageApi {
         // Implementation logic goes here
         return ResponseEntity.ok(new byte[0]);
     }
-}
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseEntity<GetProfileImageReferenceResponse> getProfileImageReference(String token, UUID applicationId) throws Exception {
+        return profileImageService.getProfileImageReference(token, applicationId);
+    }
+}

--- a/src/main/java/com/prx/backoffice/v1/profileimage/service/ProfileImageService.java
+++ b/src/main/java/com/prx/backoffice/v1/profileimage/service/ProfileImageService.java
@@ -13,6 +13,7 @@
 
 package com.prx.backoffice.v1.profileimage.service;
 
+import com.prx.backoffice.v1.profileimage.to.GetProfileImageReferenceResponse;
 import com.prx.backoffice.v1.profileimage.to.PostProfileImageResponse;
 import org.springframework.http.ResponseEntity;
 
@@ -35,5 +36,16 @@ public interface ProfileImageService {
     default ResponseEntity<PostProfileImageResponse> save(String token, UUID applicationId, byte[] image) throws Exception {
         throw new UnsupportedOperationException("Not implemented");
     }
-}
 
+    /**
+     * Retrieves the profile image reference for a user.
+     *
+     * @param token the session token of the user
+     * @param applicationId the ID of the application
+     * @return ResponseEntity with the profile image reference
+     * @throws Exception if retrieval fails
+     */
+    default ResponseEntity<GetProfileImageReferenceResponse> getProfileImageReference(String token, UUID applicationId) throws Exception {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/src/main/java/com/prx/backoffice/v1/profileimage/service/ProfileImageServiceImpl.java
+++ b/src/main/java/com/prx/backoffice/v1/profileimage/service/ProfileImageServiceImpl.java
@@ -14,6 +14,7 @@
 package com.prx.backoffice.v1.profileimage.service;
 
 import com.prx.backoffice.util.JwtUtil;
+import com.prx.backoffice.v1.profileimage.to.GetProfileImageReferenceResponse;
 import com.prx.backoffice.v1.profileimage.to.PostProfileImageResponse;
 import com.prx.commons.util.DateUtil;
 import com.prx.commons.util.HttpStatusUtil;
@@ -74,4 +75,17 @@ public class ProfileImageServiceImpl implements ProfileImageService {
         return ResponseEntity.status(HttpStatusUtil.NOT_FOUND).body(new PostProfileImageResponse(""));
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseEntity<GetProfileImageReferenceResponse> getProfileImageReference(String token, UUID applicationId) throws Exception {
+        UUID userId = JwtUtil.getUidFromToken(token);
+
+        var result = applicationRoleUserRepository.findByUserAndApplication(userId, applicationId);
+        if (Objects.nonNull(result) && result.getProfileImageRef() != null) {
+            return ResponseEntity.ok(new GetProfileImageReferenceResponse(result.getProfileImageRef()));
+        }
+        return ResponseEntity.status(HttpStatusUtil.NOT_FOUND).body(null);
+    }
 }

--- a/src/main/java/com/prx/backoffice/v1/profileimage/to/GetProfileImageReferenceResponse.java
+++ b/src/main/java/com/prx/backoffice/v1/profileimage/to/GetProfileImageReferenceResponse.java
@@ -1,0 +1,22 @@
+/*
+ *  @(#)GetProfileImageReferenceResponse.java
+ *
+ *  Copyright (c) Luis Antonio Mata Mata. All rights reserved.
+ *
+ *   All rights to this product are owned by Luis Antonio Mata Mata and may only
+ *  be used under the terms of its associated license document. You may NOT
+ *  copy, modify, sublicense, or distribute this source file or portions of
+ *  it unless previously authorized in writing by Luis Antonio Mata Mata.
+ *  In any event, this notice and the above copyright must always be included
+ *  verbatim with this file.
+ */
+
+package com.prx.backoffice.v1.profileimage.to;
+
+/**
+ * GetProfileImageReferenceResponse represents the response containing the profile image reference.
+ *
+ * @param ref The reference to the profile image.
+ */
+public record GetProfileImageReferenceResponse(String ref) {
+}

--- a/src/test/java/com/prx/backoffice/v1/profileimage/service/ProfileImageServiceImplTest.java
+++ b/src/test/java/com/prx/backoffice/v1/profileimage/service/ProfileImageServiceImplTest.java
@@ -1,0 +1,175 @@
+package com.prx.backoffice.v1.profileimage.service;
+
+import com.prx.backoffice.util.JwtUtil;
+import com.prx.backoffice.v1.profileimage.to.GetProfileImageReferenceResponse;
+import com.prx.backoffice.v1.profileimage.to.PostProfileImageResponse;
+import com.prx.persistence.general.domains.*;
+import com.prx.persistence.general.repositories.ApplicationRoleUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class ProfileImageServiceImplTest {
+
+    @Mock
+    private ApplicationRoleUserRepository applicationRoleUserRepository;
+
+    @InjectMocks
+    private ProfileImageServiceImpl profileImageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testSave_Success() throws Exception {
+
+        try(MockedStatic<JwtUtil> mockedStatic = Mockito.mockStatic(JwtUtil.class)) {
+            // Arrange
+            String token = "valid-token";
+            UUID applicationId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            byte[] image = new byte[]{1, 2, 3};
+
+            ApplicationEntity application = new ApplicationEntity();
+            application.setCodeName("app-code");
+            application.setId(applicationId);
+            RoleEntity roleEntity = new RoleEntity();
+            UserEntity userEntity = new UserEntity();
+
+            roleEntity.setActive(true);
+            roleEntity.setDescription("role-description");
+            roleEntity.setName("role-name");
+            roleEntity.setId(UUID.randomUUID());
+
+            userEntity.setId(UUID.randomUUID());
+            userEntity.setAlias("alias");
+            userEntity.setPassword("password");
+            userEntity.setEmail("email");
+            ApplicationRoleUserEntity applicationRoleUser = new ApplicationRoleUserEntity();
+            ApplicationRoleUserEntityId  applicationRoleUserEntityId = new ApplicationRoleUserEntityId();
+            applicationRoleUserEntityId.setApplicationId(applicationId);
+            applicationRoleUserEntityId.setRoleId(roleEntity.getId());
+            applicationRoleUserEntityId.setUserId(userId);
+            applicationRoleUser.setId(applicationRoleUserEntityId);
+            applicationRoleUser.setApplication(application);
+            applicationRoleUser.setRole(roleEntity);
+            applicationRoleUser.setUser(userEntity);
+            mockedStatic.when(() -> JwtUtil.getUidFromToken(anyString())).thenReturn(userId);
+            when(applicationRoleUserRepository.findByUserAndApplication(userId, applicationId))
+                    .thenReturn(applicationRoleUser);
+
+            // Act
+            ResponseEntity<PostProfileImageResponse> response = profileImageService.save(token, applicationId, image);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertTrue(response.getBody().ref().contains("app-code"));
+        }
+    }
+
+    @Test
+    void testSave_NotFound() throws Exception {
+        // Arrange
+        String token = "valid-token";
+        UUID applicationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        byte[] image = new byte[]{1, 2, 3};
+
+        try(MockedStatic<JwtUtil> mockedStatic = Mockito.mockStatic(JwtUtil.class)) {
+            mockedStatic.when(() -> JwtUtil.getUidFromToken(anyString())).thenReturn(userId);
+            when(applicationRoleUserRepository.findByUserAndApplication(userId, applicationId))
+                    .thenReturn(null);
+
+            // Act
+            ResponseEntity<PostProfileImageResponse> response = profileImageService.save(token, applicationId, image);
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals("", response.getBody().ref());
+        }
+    }
+
+    @Test
+    void testGetProfileImageReference_Success() throws Exception {
+        // Arrange
+        String token = "valid-token";
+        UUID applicationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        String profileImageRef = "path/to/image.jpg";
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setCodeName("app-code");
+        RoleEntity roleEntity = new RoleEntity();
+        UserEntity userEntity = new UserEntity();
+
+        roleEntity.setActive(true);
+        roleEntity.setDescription("role-description");
+        roleEntity.setName("role-name");
+        roleEntity.setId(UUID.randomUUID());
+
+        userEntity.setId(UUID.randomUUID());
+        userEntity.setAlias("alias");
+        userEntity.setPassword("password");
+        userEntity.setEmail("email");
+
+        ApplicationRoleUserEntity applicationRoleUser = new ApplicationRoleUserEntity();
+        ApplicationRoleUserEntityId  applicationRoleUserEntityId = new ApplicationRoleUserEntityId();
+        applicationRoleUserEntityId.setApplicationId(applicationId);
+        applicationRoleUserEntityId.setRoleId(roleEntity.getId());
+        applicationRoleUserEntityId.setUserId(userId);
+        applicationRoleUser.setId(applicationRoleUserEntityId);
+        applicationRoleUser.setApplication(application);
+        applicationRoleUser.setRole(roleEntity);
+        applicationRoleUser.setUser(userEntity);
+
+        applicationRoleUser.setProfileImageRef(profileImageRef);
+
+        try(MockedStatic<JwtUtil> mockedStatic = Mockito.mockStatic(JwtUtil.class)) {
+            mockedStatic.when(() -> JwtUtil.getUidFromToken(anyString())).thenReturn(userId);
+            when(applicationRoleUserRepository.findByUserAndApplication(userId, applicationId))
+                    .thenReturn(applicationRoleUser);
+
+            // Act
+            ResponseEntity<GetProfileImageReferenceResponse> response = profileImageService.getProfileImageReference(token, applicationId);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            assertEquals(profileImageRef, response.getBody().ref());
+        }
+    }
+
+    @Test
+    void testGetProfileImageReference_NotFound() throws Exception {
+        // Arrange
+        String token = "valid-token";
+        UUID applicationId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        try(MockedStatic<JwtUtil> mockedStatic = Mockito.mockStatic(JwtUtil.class)) {
+            mockedStatic.when(() -> JwtUtil.getUidFromToken(anyString())).thenReturn(userId);
+
+            when(applicationRoleUserRepository.findByUserAndApplication(userId, applicationId))
+                    .thenReturn(null);
+            // Act
+            ResponseEntity<GetProfileImageReferenceResponse> response = profileImageService.getProfileImageReference(token, applicationId);
+
+            // Assert
+            assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+            assertNull(response.getBody());
+        }
+
+    }
+}


### PR DESCRIPTION
### Description

This pull request adds functionality to retrieve user profile image references. Key changes include:

- Addition of the `getProfileImageReference` method to `ProfileImageService` and its implementation in `ProfileImageServiceImpl`.
- Updates to the `ProfileImageApi` and `ProfileImageController` to include a new endpoint for retrieving user profile image references.
- Creation of the `GetProfileImageReferenceResponse` class to structure the API response.
- Introduction of unit tests in `ProfileImageServiceImplTest` to ensure the added functionality works as expected.